### PR TITLE
fix file drag & drop by replacing /cygdrive with /mnt

### DIFF
--- a/makefile
+++ b/makefile
@@ -35,6 +35,7 @@ mintty:
 	$(wget) https://github.com/mintty/mintty/archive/master.zip
 	mv master.zip mintty-master.zip
 	unzip -o mintty-master.zip
+	cd mintty-master; patch -p0 -i ../mintty_drag_drop_file.patch
 	cd mintty-master/src; make LDFLAGS="-static -static-libgcc -s"
 	mkdir -p bin
 	cp mintty-master/bin/mintty.exe bin/

--- a/mintty_drag_drop_file.patch
+++ b/mintty_drag_drop_file.patch
@@ -1,0 +1,19 @@
+--- src/charset.h.orig	2016-10-07 16:12:34.000000000 +0200
++++ src/charset.h	2016-10-09 02:04:58.517284900 +0200
+@@ -79,7 +79,15 @@ extern bool widerange(xchar c);
+ 
+ static inline char *
+ path_win_w_to_posix(const wchar * wp)
+-{ return cygwin_create_path(CCP_WIN_W_TO_POSIX, wp); }
++{
++  char *p;
++  p = cygwin_create_path(CCP_WIN_W_TO_POSIX, wp);
++  if (strncmp("/cygdrive/", p, 10) == 0) {
++    strncpy(p, "/mnt/", 5);
++    strcpy(p+5, p+10);
++  }
++  return p;
++}
+ 
+ static inline wchar *
+ path_posix_to_win_w(const char * p)


### PR DESCRIPTION
Hi,

I am used to dragging and dropping files a lot. However, files on the disk should be dropped with names like `/mnt/c/pagefile.sys` instead of `/cygdrive/c/pagefile.sys`.

The most simple way is to
`$ sudo ln -s /mnt /cygdrive`
However, this requires a `sudo` and the change of the root content, whereas in my opinion, wsltty should not change the LXSS.

Another simple soluton without changing the `newlib-cygwin` is to replace "/cygdrive" with "/mnt", as this patch does.

Of course there is still a known issue: the installation folder of wsltty will still be recognized as "/". But usually users will not visit the installation directory of wsltty from the Linux subsystem. Therefore this simple patch is enough for the most cases.

Best regards