### PR TITLE
Fix missing icons

### DIFF
--- a/config-distros.sh
+++ b/config-distros.sh
@@ -139,7 +139,7 @@ do
     	# remove trailing newline that above command introduces
     	executable="${executable%"${executable##*[![:space:]]}"}"
     	if [ -r "$ProgramW6432/WindowsApps/$instdir/$executable" ]
-    	then	icon="%PROGRAMFILES%\\WindowsApps\\$instdir\\$executable"
+    	then	icon="%PROGRAMFILES%/WindowsApps/$instdir/$executable"
     	elif [ -r "$ProgramW6432/WindowsApps/$instdir/images/icon.ico" ]
     	then	icon="%PROGRAMFILES%/WindowsApps/$instdir/images/icon.ico"
     	else	icon="%LOCALAPPDATA%/wsltty/wsl.ico"

--- a/config-distros.sh
+++ b/config-distros.sh
@@ -141,6 +141,7 @@ do
       if [ -r "$ProgramW6432/WindowsApps/$instdir/$executable" ]
       then  icon="%PROGRAMFILES%\\WindowsApps\\$instdir\\$executable"
       else  icon="%LOCALAPPDATA%/wsltty/wsl.ico"
+      fi
     else
       icon="%LOCALAPPDATA%/lxss/bash.ico"
       root="$basepath"

--- a/config-distros.sh
+++ b/config-distros.sh
@@ -129,16 +129,19 @@ do
     basepath=`regtool get "$lxss/$guid/BasePath"`
     if package=`regtool -q get "$lxss/$guid/PackageFamilyName"`
     then
-    	instdir=`regtool get "$schema/$package/Schemas/PackageFullName"`
-    	if [ -r "$ProgramW6432/WindowsApps/$instdir/images/icon.ico" ]
-    	then	icon="%PROGRAMFILES%/WindowsApps/$instdir/images/icon.ico"
-    	else	icon="%LOCALAPPDATA%/wsltty/wsl.ico"
-    	fi
-    	root="$basepath/rootfs"
-    else
-    	icon="%LOCALAPPDATA%/lxss/bash.ico"
-    	root="$basepath"
-    fi
+  	instdir=`regtool get "$schema/$package/Schemas/PackageFullName"`
+
+  	# get actual executable path (may not match $distro) from the app manifest
+  	manifest="$ProgramW6432/WindowsApps/$instdir/AppxManifest.xml"
+  	psh_cmd='([xml]$(Get-Content '"\"$manifest\""')).Package.Applications.Application.Executable'
+  	executable=`powershell "$psh_cmd"`
+
+  	# remove trailing newline that above command introduces
+  	executable="${executable%"${executable##*[![:space:]]}"}"
+  	if [ -r "$ProgramW6432/WindowsApps/$instdir/$executable" ]
+  	then	icon="%PROGRAMFILES%\\WindowsApps\\$instdir\\$executable"
+  	else	icon="%LOCALAPPDATA%/wsltty/wsl.ico"
+  	fi
 
     minttyargs='--wsl --rootfs="'"$root"'" --configdir="%APPDATA%\wsltty" -o Locale=C -o Charset=UTF-8 /bin/wslbridge '
     minttyargs='--WSL="'"$distro"'" --configdir="%APPDATA%\wsltty"'

--- a/config-distros.sh
+++ b/config-distros.sh
@@ -140,8 +140,11 @@ do
     	executable="${executable%"${executable##*[![:space:]]}"}"
     	if [ -r "$ProgramW6432/WindowsApps/$instdir/$executable" ]
     	then	icon="%PROGRAMFILES%\\WindowsApps\\$instdir\\$executable"
+    	elif [ -r "$ProgramW6432/WindowsApps/$instdir/images/icon.ico" ]
+    	then	icon="%PROGRAMFILES%/WindowsApps/$instdir/images/icon.ico"
     	else	icon="%LOCALAPPDATA%/wsltty/wsl.ico"
     	fi
+    	root="$basepath/rootfs"
     else
     	icon="%LOCALAPPDATA%/lxss/bash.ico"
     	root="$basepath"

--- a/config-distros.sh
+++ b/config-distros.sh
@@ -117,47 +117,47 @@ do
     distro=`regtool get "$lxss/$guid/DistributionName"`
     case "$distro" in
     Legacy)
-      name="Bash on Windows"
-      launch=
-      launcher="$SYSTEMROOT/System32/bash.exe"
-      ;;
-    *)  name="$distro"
-      launch="$distro"
-      launcher="$LOCALAPPDATA/Microsoft/WindowsApps/$distro.exe"
-      ;;
+    	name="Bash on Windows"
+    	launch=
+    	launcher="$SYSTEMROOT/System32/bash.exe"
+    	;;
+    *)	name="$distro"
+    	launch="$distro"
+    	launcher="$LOCALAPPDATA/Microsoft/WindowsApps/$distro.exe"
+    	;;
     esac
     basepath=`regtool get "$lxss/$guid/BasePath"`
     if package=`regtool -q get "$lxss/$guid/PackageFamilyName"`
     then
-      instdir=`regtool get "$schema/$package/Schemas/PackageFullName"`
+    	instdir=`regtool get "$schema/$package/Schemas/PackageFullName"`
 
-      # get actual executable path (may not match $distro) from the app manifest
-      manifest="$ProgramW6432/WindowsApps/$instdir/AppxManifest.xml"
-      psh_cmd='([xml]$(Get-Content '"\"$manifest\""')).Package.Applications.Application.Executable'
-      executable=`powershell "$psh_cmd"`
+    	# get actual executable path (may not match $distro) from the app manifest
+    	manifest="$ProgramW6432/WindowsApps/$instdir/AppxManifest.xml"
+    	psh_cmd='([xml]$(Get-Content '"\"$manifest\""')).Package.Applications.Application.Executable'
+    	executable=`powershell "$psh_cmd"`
 
-      # remove trailing newline that above command introduces
-      executable="${executable%"${executable##*[![:space:]]}"}"
-      if [ -r "$ProgramW6432/WindowsApps/$instdir/$executable" ]
-      then  icon="%PROGRAMFILES%\\WindowsApps\\$instdir\\$executable"
-      else  icon="%LOCALAPPDATA%/wsltty/wsl.ico"
-      fi
+    	# remove trailing newline that above command introduces
+    	executable="${executable%"${executable##*[![:space:]]}"}"
+    	if [ -r "$ProgramW6432/WindowsApps/$instdir/$executable" ]
+    	then	icon="%PROGRAMFILES%\\WindowsApps\\$instdir\\$executable"
+    	else	icon="%LOCALAPPDATA%/wsltty/wsl.ico"
+    	fi
     else
-      icon="%LOCALAPPDATA%/lxss/bash.ico"
-      root="$basepath"
+    	icon="%LOCALAPPDATA%/lxss/bash.ico"
+    	root="$basepath"
     fi
 
     minttyargs='--wsl --rootfs="'"$root"'" --configdir="%APPDATA%\wsltty" -o Locale=C -o Charset=UTF-8 /bin/wslbridge '
     minttyargs='--WSL="'"$distro"'" --configdir="%APPDATA%\wsltty"'
     #if [ -z "$launch" ]
-    #then  bridgeargs='-t /bin/bash'
-    #else  bridgeargs='-l "'"$launch"'" -t /bin/bash'
+    #then	bridgeargs='-t /bin/bash'
+    #else	bridgeargs='-l "'"$launch"'" -t /bin/bash'
     #fi
     bridgeargs='--distro-guid "'"$guid"'" -t /bin/bash'
     bridgeargs='--distro-guid "'"$guid"'" -t'
 
     ok=true;;
-  "")  # WSL default installation
+  "")	# WSL default installation
     distro=
     name=WSL
     icon="%LOCALAPPDATA%/wsltty/wsl.ico"
@@ -223,7 +223,7 @@ do
 
         # default desktop shortcut in ~ -> Desktop
         if [ "$name" = "WSL" ]
-        then  cmd /C copy "$name Terminal.lnk" "%USERPROFILE%\\Desktop"
+        then	cmd /C copy "$name Terminal.lnk" "%USERPROFILE%\\Desktop"
         fi
 
         # launch script in ~ -> WSLtty home, WindowsApps launch folder

--- a/config-distros.sh
+++ b/config-distros.sh
@@ -117,43 +117,46 @@ do
     distro=`regtool get "$lxss/$guid/DistributionName"`
     case "$distro" in
     Legacy)
-    	name="Bash on Windows"
-    	launch=
-    	launcher="$SYSTEMROOT/System32/bash.exe"
-    	;;
-    *)	name="$distro"
-    	launch="$distro"
-    	launcher="$LOCALAPPDATA/Microsoft/WindowsApps/$distro.exe"
-    	;;
+      name="Bash on Windows"
+      launch=
+      launcher="$SYSTEMROOT/System32/bash.exe"
+      ;;
+    *)  name="$distro"
+      launch="$distro"
+      launcher="$LOCALAPPDATA/Microsoft/WindowsApps/$distro.exe"
+      ;;
     esac
     basepath=`regtool get "$lxss/$guid/BasePath"`
     if package=`regtool -q get "$lxss/$guid/PackageFamilyName"`
     then
-  	instdir=`regtool get "$schema/$package/Schemas/PackageFullName"`
+      instdir=`regtool get "$schema/$package/Schemas/PackageFullName"`
 
-  	# get actual executable path (may not match $distro) from the app manifest
-  	manifest="$ProgramW6432/WindowsApps/$instdir/AppxManifest.xml"
-  	psh_cmd='([xml]$(Get-Content '"\"$manifest\""')).Package.Applications.Application.Executable'
-  	executable=`powershell "$psh_cmd"`
+      # get actual executable path (may not match $distro) from the app manifest
+      manifest="$ProgramW6432/WindowsApps/$instdir/AppxManifest.xml"
+      psh_cmd='([xml]$(Get-Content '"\"$manifest\""')).Package.Applications.Application.Executable'
+      executable=`powershell "$psh_cmd"`
 
-  	# remove trailing newline that above command introduces
-  	executable="${executable%"${executable##*[![:space:]]}"}"
-  	if [ -r "$ProgramW6432/WindowsApps/$instdir/$executable" ]
-  	then	icon="%PROGRAMFILES%\\WindowsApps\\$instdir\\$executable"
-  	else	icon="%LOCALAPPDATA%/wsltty/wsl.ico"
-  	fi
+      # remove trailing newline that above command introduces
+      executable="${executable%"${executable##*[![:space:]]}"}"
+      if [ -r "$ProgramW6432/WindowsApps/$instdir/$executable" ]
+      then  icon="%PROGRAMFILES%\\WindowsApps\\$instdir\\$executable"
+      else  icon="%LOCALAPPDATA%/wsltty/wsl.ico"
+    else
+      icon="%LOCALAPPDATA%/lxss/bash.ico"
+      root="$basepath"
+    fi
 
     minttyargs='--wsl --rootfs="'"$root"'" --configdir="%APPDATA%\wsltty" -o Locale=C -o Charset=UTF-8 /bin/wslbridge '
     minttyargs='--WSL="'"$distro"'" --configdir="%APPDATA%\wsltty"'
     #if [ -z "$launch" ]
-    #then	bridgeargs='-t /bin/bash'
-    #else	bridgeargs='-l "'"$launch"'" -t /bin/bash'
+    #then  bridgeargs='-t /bin/bash'
+    #else  bridgeargs='-l "'"$launch"'" -t /bin/bash'
     #fi
     bridgeargs='--distro-guid "'"$guid"'" -t /bin/bash'
     bridgeargs='--distro-guid "'"$guid"'" -t'
 
     ok=true;;
-  "")	# WSL default installation
+  "")  # WSL default installation
     distro=
     name=WSL
     icon="%LOCALAPPDATA%/wsltty/wsl.ico"
@@ -219,7 +222,7 @@ do
 
         # default desktop shortcut in ~ -> Desktop
         if [ "$name" = "WSL" ]
-        then	cmd /C copy "$name Terminal.lnk" "%USERPROFILE%\\Desktop"
+        then  cmd /C copy "$name Terminal.lnk" "%USERPROFILE%\\Desktop"
         fi
 
         # launch script in ~ -> WSLtty home, WindowsApps launch folder


### PR DESCRIPTION
Since the previous fixed path `images/icon.ico` stopped working for the store distros, modified the installation script to use the executable path for the icon. Since executable path is not the same as the distro name we get from the registry, read it from AppxManifest.xml as suggested by @Biswa96 in https://github.com/mintty/wsltty/issues/110#issuecomment-395999015.

It works on my machine but could use more testing. For example I had changed the owner of `C:Program Files\WindowsApps` to my user so I can open it in explorer -- there is a chance the path may not be readable by the script by default.