### PR TITLE
Removed  installation instruction for choco and scoop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Mintty as a terminal for WSL (Windows Subsystem for Linux).
+Mintty as a terminal for WSL (Windows Subsystem for Linux).  
 
 <img align=right src=wsltty.png>
 
@@ -49,23 +49,6 @@ The optional first parameter designates the installation target,
 the optional second parameter designates the configuration directory.
 
 ### Installation with other package management environments ###
-
-#### Chocolatey ####
-
-If you use the [Chocolatey package manager](https://chocolatey.org/), 
-invoke one of
-<img height=222 align=right src=https://github.com/mintty/wsltty.appx/raw/master/wsltty.appx.png>
-* `choco install wsltty`
-* `choco upgrade wsltty`
-
-#### Scoop ####
-
-If you use the [Scoop package manager](https://scoop.sh/), 
-* `scoop bucket add extras`
-
-then, invoke one of
-* `scoop install wsltty`
-* `scoop update wsltty`
 
 #### Windows Appx package ####
 


### PR DESCRIPTION
The installation files provided with each release is simple enough and trusted. 
Scoop and choco aren't officially maintained thus I think It shouldn't be promoted. The current version provided by these managers is not always the latest and what more important it yields confusing errors (A glance at the issue tab prove it.). I tried it both myself, and nor each of them passes without my help. 
Moreover, I have concerns that if an author doesn't maintain choco then there is a possibility that an unknown distributor embeds an insecure PowerShell script.
Additionally, I edited the thumbnail to show that this is just a terminal emulator, and it lets you make custom whatever you like and help it to compete with a new windows terminal.